### PR TITLE
pass with credentials to http client api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 .idea/workspace.xml
 .idea/tasks.xml
 node_modules/
-build/
 private/

--- a/build/assembler.d.ts
+++ b/build/assembler.d.ts
@@ -1,0 +1,22 @@
+export interface Token {
+    name: string;
+    value?: any;
+}
+export declare type ObjectIndex = string | number;
+export interface AssemblerOptions {
+    onArrayPush?: (value: any, stack: any[], keyStack?: ObjectIndex[]) => boolean | void;
+    onKeyValueAdd?: (key: ObjectIndex, value: any, stack?: any[], keyStack?: ObjectIndex[]) => boolean | void;
+}
+export declare class Assembler {
+    stack: any[];
+    keyStack: ObjectIndex[];
+    current: any;
+    key: ObjectIndex | null;
+    private onArrayPush;
+    private onKeyValueAdd;
+    constructor(options?: AssemblerOptions);
+    private _pushStacks;
+    private _popStacks;
+    private _saveValue;
+    process(token: Token): void;
+}

--- a/build/assembler.js
+++ b/build/assembler.js
@@ -1,0 +1,79 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var Assembler = (function () {
+    function Assembler(options) {
+        if (options === void 0) { options = {}; }
+        this.stack = [];
+        this.keyStack = [];
+        this.current = null;
+        this.key = null;
+        this.onArrayPush = options.onArrayPush;
+        this.onKeyValueAdd = options.onKeyValueAdd;
+    }
+    Assembler.prototype._pushStacks = function (newCurrent) {
+        if (this.current)
+            this.keyStack.push(this.key);
+        this.stack.push(this.current = newCurrent);
+    };
+    Assembler.prototype._popStacks = function () {
+        var stack = this.stack;
+        stack.pop();
+        this.current = stack[stack.length - 1] || null;
+        this.key = this.keyStack.pop();
+    };
+    Assembler.prototype._saveValue = function (value) {
+        var _a = this, current = _a.current, key = _a.key;
+        if (current) {
+            if (Array.isArray(current)) {
+                var onArrayPush = this.onArrayPush;
+                if (!onArrayPush || onArrayPush.call(this, value, this.stack, this.keyStack) !== false) {
+                    current.push(value);
+                    this.key = key + 1;
+                }
+            }
+            else {
+                var onKeyValueAdd = this.onKeyValueAdd;
+                if (!onKeyValueAdd || onKeyValueAdd.call(this, key, value, this.stack, this.keyStack) !== false) {
+                    current[key] = value;
+                }
+                this.key = null;
+            }
+        }
+        else {
+            this.current = value;
+        }
+    };
+    Assembler.prototype.process = function (token) {
+        switch (token.name) {
+            case 'startObject':
+                this._pushStacks({});
+                break;
+            case 'startArray':
+                this._pushStacks([]);
+                this.key = 0;
+                break;
+            case 'endObject':
+            case 'endArray':
+                var finishedCurrent = this.current;
+                this._popStacks();
+                this._saveValue(finishedCurrent);
+                break;
+            case 'keyValue':
+                this.key = token.value;
+                break;
+            case 'stringValue':
+            case 'nullValue':
+            case 'trueValue':
+            case 'falseValue':
+                this._saveValue(token.value);
+                break;
+            case 'numberValue':
+                this._saveValue(parseFloat(token.value));
+                break;
+            default:
+                break;
+        }
+    };
+    return Assembler;
+}());
+exports.Assembler = Assembler;

--- a/build/druidRequester.d.ts
+++ b/build/druidRequester.d.ts
@@ -1,0 +1,41 @@
+import { PlywoodRequester, PlywoodLocator, Location, AuthToken } from 'plywood-base-api';
+export declare type Protocol = 'plain' | 'tls-loose' | 'tls';
+export interface DruidUrlBuilder {
+    (location: Location, secure: boolean): string;
+}
+export interface DruidRequestDecorator {
+    (decoratorRequest: DecoratorRequest, decoratorContext: {
+        [k: string]: any;
+    }): Decoration | Promise<Decoration>;
+}
+export interface DruidRequesterParameters {
+    locator?: PlywoodLocator;
+    host?: string;
+    timeout?: number;
+    protocol?: Protocol;
+    ca?: string;
+    cert?: any;
+    key?: any;
+    passphrase?: string;
+    urlBuilder?: DruidUrlBuilder;
+    requestDecorator?: DruidRequestDecorator;
+    authToken?: AuthToken;
+    socksHost?: string;
+    socksUsername?: string;
+    socksPassword?: string;
+}
+export interface DecoratorRequest {
+    method: string;
+    url: string;
+    query: any;
+}
+export interface Decoration {
+    method?: string;
+    url?: string;
+    headers?: Record<string, string>;
+    query?: string | object;
+    resultType?: string;
+    timestampOverride?: string;
+}
+export declare function applyAuthTokenToHeaders(headers: Record<string, string>, authToken: AuthToken): void;
+export declare function druidRequesterFactory(parameters: DruidRequesterParameters): PlywoodRequester<any>;

--- a/build/druidRequester.js
+++ b/build/druidRequester.js
@@ -1,0 +1,336 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var tslib_1 = require("tslib");
+var plywood_base_api_1 = require("plywood-base-api");
+var readable_stream_1 = require("readable-stream");
+var request = require("request");
+var hasOwnProperty = require("has-own-prop");
+var requestPromise = require("request-promise-native");
+var concat = require("concat-stream");
+var PlainAgent = require("socks5-http-client/lib/Agent");
+var SecureAgent = require("socks5-https-client/lib/Agent");
+var Combo = require("stream-json/Combo");
+var rowBuilder_1 = require("./rowBuilder");
+var withCredentials = { withCredentials: true };
+function getDataSourcesFromQuery(query) {
+    var queryDataSource = query.dataSource;
+    if (!queryDataSource)
+        return [];
+    if (typeof queryDataSource === 'string') {
+        return [queryDataSource];
+    }
+    else if (queryDataSource.type === "union") {
+        return queryDataSource.dataSources;
+    }
+    else {
+        throw new Error("unsupported datasource type '" + queryDataSource.type + "'");
+    }
+}
+function basicUrlBuilder(location, secure) {
+    var s = '';
+    var defaultPort = 8082;
+    if (secure) {
+        s = 's';
+        defaultPort += 200;
+    }
+    return "http" + s + "://" + location.hostname + ":" + (location.port || defaultPort);
+}
+function applyAuthTokenToHeaders(headers, authToken) {
+    if (!authToken)
+        return;
+    switch (authToken.type) {
+        case 'basic-auth':
+            if (typeof authToken.username !== 'string')
+                throw new Error('basic-auth must set username');
+            if (typeof authToken.password !== 'string')
+                throw new Error('basic-auth must set password');
+            headers["Authorization"] = "Basic " + Buffer.from(authToken.username + ':' + authToken.password).toString('base64');
+            break;
+        case 'imply-token-hmac':
+            if (typeof authToken.implyToken !== 'string')
+                throw new Error('imply-token-hmac must set implyToken');
+            if (typeof authToken.implyHmac !== 'string')
+                throw new Error('imply-token-hmac must set implyHmac');
+            headers["X-Imply-Token"] = authToken.implyToken;
+            headers["X-Imply-HMAC"] = authToken.implyHmac;
+            headers["Imply-Token"] = authToken.implyToken;
+            headers["Imply-HMAC"] = authToken.implyHmac;
+            break;
+        default:
+            throw new Error("unknown auth token type '" + authToken.type + "'");
+    }
+}
+exports.applyAuthTokenToHeaders = applyAuthTokenToHeaders;
+function druidRequesterFactory(parameters) {
+    var locator = parameters.locator, host = parameters.host, timeout = parameters.timeout, protocol = parameters.protocol, urlBuilder = parameters.urlBuilder, requestDecorator = parameters.requestDecorator, authToken = parameters.authToken, socksHost = parameters.socksHost;
+    if (!protocol)
+        protocol = 'plain';
+    var secure = protocol === 'tls' || protocol === 'tls-loose';
+    if (!locator) {
+        if (!host)
+            throw new Error("must have a `host` or a `locator`");
+        locator = plywood_base_api_1.basicLocator(host, secure ? 8282 : 8082);
+    }
+    if (!urlBuilder) {
+        urlBuilder = basicUrlBuilder;
+    }
+    var agentClass = null;
+    var agentOptions = null;
+    if (socksHost) {
+        var socksLocation = plywood_base_api_1.hostToLocation(socksHost, 1080);
+        agentClass = secure ? SecureAgent : PlainAgent;
+        agentOptions = {
+            socksHost: socksLocation.hostname,
+            socksPort: socksLocation.port
+        };
+        if (parameters.socksUsername)
+            agentOptions.socksUsername = parameters.socksUsername;
+        if (parameters.socksPassword)
+            agentOptions.socksPassword = parameters.socksPassword;
+    }
+    function requestOptionsWithDecoration(opt) {
+        return Promise.resolve()
+            .then(function () {
+            var query = opt.query, context = opt.context, options = opt.options;
+            if (agentClass) {
+                options.agentClass = agentClass;
+                options.agentOptions = agentOptions;
+            }
+            if (secure) {
+                options.strictSSL = (protocol === 'tls');
+                if (parameters.ca)
+                    options.ca = parameters.ca;
+                if (parameters.cert)
+                    options.cert = parameters.cert;
+                if (parameters.key)
+                    options.key = parameters.key;
+                if (parameters.passphrase)
+                    options.passphrase = parameters.passphrase;
+            }
+            options.headers = options.headers || {};
+            applyAuthTokenToHeaders(options.headers, authToken);
+            if (requestDecorator) {
+                var decorationPromise = requestDecorator({
+                    method: options.method,
+                    url: options.url,
+                    query: JSON.parse(JSON.stringify(query))
+                }, context['decoratorContext']);
+                if (decorationPromise) {
+                    return Promise.resolve(decorationPromise)
+                        .then(function (decoration) {
+                        if (!decoration)
+                            return options;
+                        if (decoration.method) {
+                            options.method = decoration.method;
+                        }
+                        if (decoration.url) {
+                            options.url = decoration.url;
+                        }
+                        if (decoration.headers) {
+                            Object.assign(options.headers, decoration.headers);
+                        }
+                        if (decoration.query) {
+                            if (typeof decoration.query === 'string') {
+                                options.body = decoration.query;
+                            }
+                            else {
+                                options.body = JSON.stringify(decoration.query);
+                            }
+                        }
+                        if (decoration.resultType) {
+                            options.resultType = decoration.resultType;
+                        }
+                        if (decoration.timestampOverride) {
+                            options.timestampOverride = decoration.timestampOverride;
+                        }
+                        return options;
+                    });
+                }
+            }
+            return options;
+        });
+    }
+    function requestPromiseWithDecoration(opt) {
+        return requestOptionsWithDecoration(opt).then(function (options) { return requestPromise(tslib_1.__assign({}, options, withCredentials)); });
+    }
+    function failIfNoDatasource(url, query, timeout) {
+        return requestPromiseWithDecoration({
+            query: { queryType: "sourceList" },
+            context: {},
+            options: {
+                method: "GET",
+                url: url + "/druid/v2/datasources",
+                json: true,
+                timeout: timeout
+            }
+        })
+            .then(function (resp) {
+            var dataSourcesInQuery = getDataSourcesFromQuery(query);
+            if (dataSourcesInQuery.every(function (dataSource) { return resp.indexOf(dataSource) < 0; })) {
+                throw new Error("No such datasource '" + dataSourcesInQuery[0] + "'");
+            }
+            return null;
+        });
+    }
+    return function (req) {
+        var context = req.context || {};
+        var query = req.query;
+        var queryType = query.queryType, intervals = query.intervals;
+        if (!queryType && typeof query.query === 'string') {
+            queryType = 'sql';
+        }
+        var stream = new readable_stream_1.PassThrough({
+            objectMode: true
+        });
+        if (intervals && (intervals === "1000-01-01/1000-01-02" || !intervals.length)) {
+            process.nextTick(function () {
+                stream.push(null);
+            });
+            return stream;
+        }
+        function streamError(e) {
+            e.query = query;
+            stream.emit('error', e);
+            stream.end();
+        }
+        var url;
+        locator()
+            .then(function (location) {
+            url = urlBuilder(location, secure);
+            if (queryType === "status") {
+                requestPromiseWithDecoration({
+                    query: query,
+                    context: context,
+                    options: {
+                        method: "GET",
+                        url: url + '/status',
+                        json: true,
+                        timeout: timeout
+                    }
+                })
+                    .then(function (resp) {
+                    stream.push(resp);
+                    stream.push(null);
+                }, streamError);
+                return;
+            }
+            if (queryType === "introspect" || queryType === "sourceList") {
+                requestPromiseWithDecoration({
+                    query: query,
+                    context: context,
+                    options: {
+                        method: "GET",
+                        url: url + "/druid/v2/datasources/" + (queryType === "introspect" ? getDataSourcesFromQuery(query)[0] : ''),
+                        json: true,
+                        timeout: timeout
+                    }
+                })
+                    .then(function (resp) {
+                    if (queryType === "introspect") {
+                        if (Array.isArray(resp.dimensions) && !resp.dimensions.length &&
+                            Array.isArray(resp.metrics) && !resp.metrics.length) {
+                            return failIfNoDatasource(url, query, timeout).then(function () {
+                                var err = new Error("Can not use GET route, data is probably in a real-time node or more than a two weeks old. Try segmentMetadata instead.");
+                                err.query = query;
+                                throw err;
+                            });
+                        }
+                    }
+                    return resp;
+                })
+                    .then(function (resp) {
+                    stream.push(resp);
+                    stream.push(null);
+                }, streamError);
+                return;
+            }
+            if (timeout != null) {
+                query.context || (query.context = {});
+                query.context.timeout = timeout;
+            }
+            requestOptionsWithDecoration({
+                query: query,
+                context: context,
+                options: {
+                    method: "POST",
+                    url: url + "/druid/v2/" + (queryType === 'sql' ? 'sql/' : '') + (context['pretty'] ? '?pretty' : ''),
+                    body: JSON.stringify(query),
+                    headers: {
+                        "Content-type": "application/json"
+                    },
+                    timeout: timeout
+                }
+            })
+                .then(function (options) {
+                request(tslib_1.__assign({}, options, withCredentials))
+                    .on('error', function (err) {
+                    if (err.message === 'ETIMEDOUT' || err.message === 'ESOCKETTIMEDOUT')
+                        err = new Error("timeout");
+                    streamError(err);
+                })
+                    .on('response', function (response) {
+                    if (response.statusCode !== 200) {
+                        response.on('error', streamError);
+                        response.pipe(concat(function (resp) {
+                            resp = String(resp);
+                            var error;
+                            try {
+                                var body = JSON.parse(resp);
+                                if (body && body.error === "Query timeout") {
+                                    error = new Error("timeout");
+                                }
+                                else {
+                                    var message = void 0;
+                                    if (body && typeof body.error === 'string') {
+                                        message = body.error;
+                                        if (typeof body.errorMessage === 'string') {
+                                            message = message + ": " + body.errorMessage;
+                                        }
+                                    }
+                                    else {
+                                        message = "Bad status code (" + response.statusCode + ")";
+                                    }
+                                    error = new Error(message);
+                                    error.query = query;
+                                    if (body && typeof body.host === 'string')
+                                        error.host = body.host;
+                                }
+                            }
+                            catch (e) {
+                                error = new Error("bad response");
+                            }
+                            streamError(error);
+                        }));
+                        return;
+                    }
+                    var rowBuilder = new rowBuilder_1.RowBuilder({
+                        resultType: options.resultType || queryType,
+                        resultFormat: query.resultFormat,
+                        timestamp: options.timestampOverride || (hasOwnProperty(context, 'timestamp') ? context['timestamp'] : 'timestamp'),
+                        ignorePrefix: context['ignorePrefix'],
+                        dummyPrefix: context['dummyPrefix']
+                    });
+                    rowBuilder.on('meta', function (meta) {
+                        stream.emit('meta', meta);
+                    });
+                    rowBuilder.on('end', function () {
+                        if (!rowBuilder.maybeNoDataSource) {
+                            stream.end();
+                            return;
+                        }
+                        failIfNoDatasource(url, query, timeout)
+                            .then(function () {
+                            stream.end();
+                        }, streamError);
+                    });
+                    response
+                        .pipe(new Combo({ packKeys: true, packStrings: true, packNumbers: true }))
+                        .pipe(rowBuilder)
+                        .pipe(stream, { end: false });
+                });
+            }, streamError);
+        });
+        return stream;
+    };
+}
+exports.druidRequesterFactory = druidRequesterFactory;

--- a/build/rowBuilder.d.ts
+++ b/build/rowBuilder.d.ts
@@ -1,0 +1,21 @@
+/// <reference types="node" />
+import { Transform, TransformOptions } from "stream";
+export interface RowBuilderOptions extends TransformOptions {
+    resultType: string;
+    resultFormat?: string;
+    timestamp?: string | null;
+    ignorePrefix?: string | null;
+    dummyPrefix?: string | null;
+}
+export declare class RowBuilder extends Transform {
+    static cleanupIgnoreFactory(ignorePrefix: string | null): (obj: any) => void;
+    static cleanupDummyFactory(dummyPrefix: string | null): (obj: any) => void;
+    private assembler;
+    private flushRoot;
+    private metaEmitted;
+    private columns;
+    maybeNoDataSource: boolean;
+    constructor(options: RowBuilderOptions);
+    _transform(chunk: any, encoding: any, callback: any): void;
+    _flush(callback: any): void;
+}

--- a/build/rowBuilder.js
+++ b/build/rowBuilder.js
@@ -1,0 +1,230 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var tslib_1 = require("tslib");
+var stream_1 = require("stream");
+var assembler_1 = require("./assembler");
+var RowBuilder = (function (_super) {
+    tslib_1.__extends(RowBuilder, _super);
+    function RowBuilder(options) {
+        var _this = this;
+        options.readableObjectMode = true;
+        options.writableObjectMode = true;
+        _this = _super.call(this, options) || this;
+        var resultType = options.resultType, resultFormat = options.resultFormat, _a = options.timestamp, timestamp = _a === void 0 ? 'timestamp' : _a, _b = options.ignorePrefix, ignorePrefix = _b === void 0 ? null : _b, _c = options.dummyPrefix, dummyPrefix = _c === void 0 ? null : _c;
+        _this.maybeNoDataSource = resultType !== 'sql';
+        var cleanupIgnore = RowBuilder.cleanupIgnoreFactory(ignorePrefix);
+        var cleanupDummy = RowBuilder.cleanupDummyFactory(dummyPrefix);
+        var onArrayPush = null;
+        var onKeyValueAdd = function (key, value) {
+            _this.maybeNoDataSource = false;
+            return true;
+        };
+        switch (resultType) {
+            case 'timeseries':
+            case 'timeBoundary':
+                onArrayPush = function (value, stack, keyStack) {
+                    if (keyStack.length === 0) {
+                        var d = value.result;
+                        if (timestamp)
+                            d[timestamp] = new Date(value.timestamp);
+                        if (cleanupIgnore)
+                            cleanupIgnore(d);
+                        if (cleanupDummy)
+                            cleanupDummy(d);
+                        _this.push(d);
+                        return false;
+                    }
+                    return true;
+                };
+                break;
+            case 'topN':
+                onArrayPush = function (value, stack, keyStack) {
+                    if (keyStack.length === 2 && keyStack[1] === 'result') {
+                        var d = value;
+                        if (timestamp)
+                            d.timestamp = new Date(stack[1].timestamp);
+                        if (cleanupIgnore)
+                            cleanupIgnore(d);
+                        if (cleanupDummy)
+                            cleanupDummy(d);
+                        _this.push(d);
+                        return false;
+                    }
+                    return true;
+                };
+                break;
+            case 'groupBy':
+                onArrayPush = function (value, stack, keyStack) {
+                    if (keyStack.length === 0) {
+                        var d = value.event;
+                        if (timestamp)
+                            d[timestamp] = new Date(value.timestamp);
+                        if (cleanupIgnore)
+                            cleanupIgnore(d);
+                        if (cleanupDummy)
+                            cleanupDummy(d);
+                        _this.push(d);
+                        return false;
+                    }
+                    return true;
+                };
+                break;
+            case 'select':
+                onArrayPush = function (value, stack, keyStack) {
+                    if (keyStack.length === 3 && keyStack[2] === 'events') {
+                        var d = value.event;
+                        if (timestamp)
+                            d[timestamp] = new Date(d.timestamp);
+                        if (timestamp !== 'timestamp')
+                            delete d['timestamp'];
+                        if (cleanupIgnore)
+                            cleanupIgnore(d);
+                        if (cleanupDummy)
+                            cleanupDummy(d);
+                        _this.push(d);
+                        return false;
+                    }
+                    return true;
+                };
+                onKeyValueAdd = function (key, value) {
+                    _this.maybeNoDataSource = false;
+                    if (key !== 'pagingIdentifiers')
+                        return true;
+                    if (_this.metaEmitted)
+                        return false;
+                    _this.emit('meta', { pagingIdentifiers: value });
+                    _this.metaEmitted = true;
+                    return false;
+                };
+                break;
+            case 'scan':
+                if (resultFormat === 'compactedList') {
+                    var columns_1 = null;
+                    onArrayPush = function (value, stack, keyStack) {
+                        if (keyStack.length === 2 && keyStack[1] === 'events') {
+                            var d = {};
+                            var n = columns_1.length;
+                            for (var i = 0; i < n; i++) {
+                                d[columns_1[i]] = value[i];
+                            }
+                            if (cleanupIgnore)
+                                cleanupIgnore(d);
+                            if (cleanupDummy)
+                                cleanupDummy(d);
+                            _this.push(d);
+                            return false;
+                        }
+                        return true;
+                    };
+                    onKeyValueAdd = function (key, value, stack, keyStack) {
+                        if (key !== 'columns' || keyStack.length !== 1)
+                            return true;
+                        columns_1 = value;
+                        return false;
+                    };
+                }
+                else {
+                    onArrayPush = function (value, stack, keyStack) {
+                        if (keyStack.length === 2 && keyStack[1] === 'events') {
+                            var d = value;
+                            if (cleanupIgnore)
+                                cleanupIgnore(d);
+                            if (cleanupDummy)
+                                cleanupDummy(d);
+                            _this.push(d);
+                            return false;
+                        }
+                        return true;
+                    };
+                }
+                break;
+            case 'segmentMetadata':
+                onArrayPush = function (value, stack, keyStack) {
+                    if (keyStack.length === 0) {
+                        var d = value;
+                        if (cleanupIgnore)
+                            cleanupIgnore(d);
+                        if (cleanupDummy)
+                            cleanupDummy(d);
+                        _this.push(d);
+                        return false;
+                    }
+                    return true;
+                };
+                break;
+            case 'sql':
+                _this.columns = [];
+                onArrayPush = function (value, stack, keyStack) {
+                    if (keyStack.length === 0) {
+                        if (_this.columns) {
+                            _this.emit('meta', {
+                                columns: _this.columns
+                            });
+                            _this.columns = null;
+                        }
+                        var d = value;
+                        if (cleanupIgnore)
+                            cleanupIgnore(d);
+                        if (cleanupDummy)
+                            cleanupDummy(d);
+                        _this.push(d);
+                        return false;
+                    }
+                    return true;
+                };
+                onKeyValueAdd = function (key, value, stack, keyStack) {
+                    if (!_this.columns)
+                        return true;
+                    _this.maybeNoDataSource = false;
+                    if (keyStack.length === 1 && keyStack[0] === 0) {
+                        _this.columns.push(String(key));
+                    }
+                    return true;
+                };
+                break;
+            default:
+                _this.flushRoot = true;
+        }
+        _this.assembler = new assembler_1.Assembler({
+            onArrayPush: onArrayPush,
+            onKeyValueAdd: onKeyValueAdd
+        });
+        return _this;
+    }
+    RowBuilder.cleanupIgnoreFactory = function (ignorePrefix) {
+        if (ignorePrefix == null)
+            return null;
+        var ignorePrefixLength = ignorePrefix.length;
+        return function (obj) {
+            for (var k in obj) {
+                if (k.substr(0, ignorePrefixLength) === ignorePrefix)
+                    delete obj[k];
+            }
+        };
+    };
+    RowBuilder.cleanupDummyFactory = function (dummyPrefix) {
+        if (dummyPrefix == null)
+            return null;
+        var dummyPrefixLength = dummyPrefix.length;
+        return function (obj) {
+            for (var k in obj) {
+                if (k.substr(0, dummyPrefixLength) === dummyPrefix) {
+                    obj[k.substr(dummyPrefixLength)] = obj[k];
+                    delete obj[k];
+                }
+            }
+        };
+    };
+    RowBuilder.prototype._transform = function (chunk, encoding, callback) {
+        this.assembler.process(chunk);
+        callback();
+    };
+    RowBuilder.prototype._flush = function (callback) {
+        if (this.flushRoot) {
+            this.push(this.assembler.current);
+        }
+        callback();
+    };
+    return RowBuilder;
+}(stream_1.Transform));
+exports.RowBuilder = RowBuilder;

--- a/src/druidRequester.ts
+++ b/src/druidRequester.ts
@@ -32,6 +32,8 @@ export interface DruidUrlBuilder {
   (location: Location, secure: boolean): string
 }
 
+const withCredentials = { withCredentials: true };
+
 export interface DruidRequestDecorator {
   (decoratorRequest: DecoratorRequest, decoratorContext: { [k: string]: any }): Decoration | Promise<Decoration>;
 }
@@ -215,7 +217,7 @@ export function druidRequesterFactory(parameters: DruidRequesterParameters): Ply
   }
 
   function requestPromiseWithDecoration(opt: RequestWithDecorationOptions): Promise<any> {
-    return requestOptionsWithDecoration(opt).then(requestPromise);
+    return requestOptionsWithDecoration(opt).then((options) => requestPromise({ ...options, ...withCredentials } as any));
   }
 
   function failIfNoDatasource(url: string, query: any, timeout: number): Promise<any> {
@@ -352,7 +354,7 @@ export function druidRequesterFactory(parameters: DruidRequesterParameters): Ply
         })
           .then(
             (options) => {
-              request(options)
+              request({ ...options, ...withCredentials } as any)
                 .on('error', (err: any) => {
                   if (err.message === 'ETIMEDOUT' || err.message === 'ESOCKETTIMEDOUT') err = new Error("timeout");
                   streamError(err);


### PR DESCRIPTION
In the browser druid requester uses [stream-http](https://www.npmjs.com/package/stream-http) which allows to send cookies via `withCredentials`, which is not supported by the type of `request` 😭 

[twister uses cookie authentication](https://trello.com/c/Kr6CR2af/4290-twister-uses-cookie-authentication)